### PR TITLE
set restart option for the db service

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -2,6 +2,7 @@ version: "3"
 services:
   db:
     image: mysql:5.7.22
+    restart: unless-stopped
     volumes:
       - ./db/mysql_data:/var/lib/mysql
     env_file: .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
   db:
     image: mysql:5.7.22
+    restart: unless-stopped
     volumes:
       - ./db/mysql_data:/var/lib/mysql
     env_file: .env
@@ -17,4 +18,3 @@ services:
       - "22222:3000"
     depends_on:
       - db
-      


### PR DESCRIPTION
workerで`yum update`したときにdockerコンテナの再起動が発生しました。このとき、dbサービスが自動起動しなかったため、https://bus.t-lab.cs.teu.ac.jp/ がしばらく落ちてました。

再発防止のため、dbサービスに`restart`オプションを設定しました。