### PR TITLE
シャトル運行なのに時刻指定ある場合に認識されない不具合

### DIFF
--- a/src/app/controllers/register_controller.rb
+++ b/src/app/controllers/register_controller.rb
@@ -58,7 +58,6 @@ class RegisterController < ApplicationController
           # シャトル運行間隔記載があれば、間隔時間を取得
           ## シャトル運行の記載があるカラムは固定ではないので、全てのカラムで検査する
           shuttle_notice_td = shuttle_notice_cell(row.css('td'))
-          binding.pry unless shuttle_notice_td.nil?
           if !shuttle_notice_td.nil? && shuttle_notice_td.inner_text =~ /\s*約?(\d*)～(\d*)分\s*/
             interval = shuttle_notice_td.inner_text.split(/\s*約?(\d*)～(\d*)分\s*/)
             rowspan = shuttle_notice_td.attribute("rowspan").value.to_i unless shuttle_notice_td.attribute("rowspan").nil?

--- a/src/app/controllers/register_controller.rb
+++ b/src/app/controllers/register_controller.rb
@@ -58,12 +58,14 @@ class RegisterController < ApplicationController
           # シャトル運行間隔記載があれば、間隔時間を取得
           ## シャトル運行の記載があるカラムは固定ではないので、全てのカラムで検査する
           shuttle_notice_td = shuttle_notice_cell(row.css('td'))
+          binding.pry unless shuttle_notice_td.nil?
           if !shuttle_notice_td.nil? && shuttle_notice_td.inner_text =~ /\s*約?(\d*)～(\d*)分\s*/
             interval = shuttle_notice_td.inner_text.split(/\s*約?(\d*)～(\d*)分\s*/)
+            rowspan = shuttle_notice_td.attribute("rowspan").value.to_i unless shuttle_notice_td.attribute("rowspan").nil?
             is_shuttle = {
               status: true,
               interval: ([interval[1].to_f, interval[2].to_f].average * 60).round,
-              count: 1
+              count: rowspan.blank? ? 1 : rowspan.to_i
             }
           # シャトル運行フラグのみがある場合
           elsif !shuttle_notice_td.nil?


### PR DESCRIPTION
# なぜやるか
シャトル運行表で`rowspan`が指定されている時に不具合が出ていた為
![image](https://user-images.githubusercontent.com/16918590/66176607-5d3a5700-e699-11e9-911d-c108506ee0bf.png)

# なにをしたか
従来のだと(なぜか)`rowspan`が1固定だったのを、attributeを見るようにした。なければ従来通り1を指定する。
