### PR TITLE
iOSデバイスで日付フォーマットがうまく行かない問題

### DIFF
--- a/spa/src/components/SearchModal/SearchModalBody.tsx
+++ b/spa/src/components/SearchModal/SearchModalBody.tsx
@@ -19,9 +19,9 @@ interface TTTOption {
 
 export function SearchModalBody(props: ModalProps) {
   const today = new Date()
-  const nowDate = formatDate(today, 'YYYY-MM-DD')
+  const nowDate = formatDate(today, 'YYYY/MM/DD')
   const nowTime = formatDate(today)
-  const maxDate = formatDate(addMonth(today, 1), 'YYYY-MM-DD')
+  const maxDate = formatDate(addMonth(today, 1), 'YYYY/MM/DD')
 
   const dispatch = useDispatch()
 
@@ -57,6 +57,7 @@ export function SearchModalBody(props: ModalProps) {
   )
 
   const dispatchSearch = useCallback(() => {
+    console.log(new Date(`${targetDate} ${targetTime}`))
     dispatch(
       thunkActionCreators.getTimetable({
         searchType: targetTimeType,
@@ -68,14 +69,14 @@ export function SearchModalBody(props: ModalProps) {
   const handleChangeDate = (event: React.FormEvent<FormControlProps & FormControl>) => {
     const { value } = event.currentTarget
     if (value !== undefined) {
-      setTargetDate(value.replace(/(\d+).*?(\d+).*?(\d+).*?/g, '$1-$2-$3'))
+      setTargetDate(value)
     }
   }
 
   const handleChangeTime = (event: React.FormEvent<FormControlProps & FormControl>) => {
     const { value } = event.currentTarget
     if (value !== undefined) {
-      setTargetTime(value.replace(/(\d+).*?(\d+).*?/g, '$1:$2'))
+      setTargetTime(value)
     }
   }
 

--- a/spa/src/components/SearchModal/SearchModalBody.tsx
+++ b/spa/src/components/SearchModal/SearchModalBody.tsx
@@ -19,9 +19,9 @@ interface TTTOption {
 
 export function SearchModalBody(props: ModalProps) {
   const today = new Date()
-  const nowDate = formatDate(today, 'YYYY/MM/DD')
+  const nowDate = formatDate(today, 'YYYY-MM-DD')
   const nowTime = formatDate(today)
-  const maxDate = formatDate(addMonth(today, 1), 'YYYY/MM/DD')
+  const maxDate = formatDate(addMonth(today, 1), 'YYYY-MM-DD')
 
   const dispatch = useDispatch()
 
@@ -57,11 +57,10 @@ export function SearchModalBody(props: ModalProps) {
   )
 
   const dispatchSearch = useCallback(() => {
-    console.log(new Date(`${targetDate} ${targetTime}`))
     dispatch(
       thunkActionCreators.getTimetable({
         searchType: targetTimeType,
-        datetime: new Date(`${targetDate} ${targetTime}`),
+        datetime: new Date(`${targetDate}T${targetTime}`),
       })
     )
   }, [dispatch, targetDate, targetTime, targetTimeType])

--- a/spa/src/components/SearchModal/SearchModalBody.tsx
+++ b/spa/src/components/SearchModal/SearchModalBody.tsx
@@ -68,14 +68,14 @@ export function SearchModalBody(props: ModalProps) {
   const handleChangeDate = (event: React.FormEvent<FormControlProps & FormControl>) => {
     const { value } = event.currentTarget
     if (value !== undefined) {
-      setTargetDate(value)
+      setTargetDate(value.replace(/(\d+).*?(\d+).*?(\d+).*?/g, '$1-$2-$3'))
     }
   }
 
   const handleChangeTime = (event: React.FormEvent<FormControlProps & FormControl>) => {
     const { value } = event.currentTarget
     if (value !== undefined) {
-      setTargetTime(value)
+      setTargetTime(value.replace(/(\d+).*?(\d+).*?/g, '$1:$2'))
     }
   }
 


### PR DESCRIPTION
ブラウザごとにフォーマットが違う件。マジかよ

https://ka2.org/handling-of-javascript-date-object-is-different-for-each-browser/